### PR TITLE
Correct `Object`'s `template_uuid` and `template_version` attributes

### DIFF
--- a/misp-core-format/raw.md
+++ b/misp-core-format/raw.md
@@ -769,15 +769,17 @@ description is represented as a JSON string. id **SHALL** be present.
 
 #### template\_uuid
 
-uuid represents the Universally Unique IDentifier (UUID) [@!RFC4122] of the template used to create the object. The uuid **MUST** be preserved
+template_uuid represents the Universally Unique IDentifier (UUID) [@!RFC4122] of the template used to create the object. The uuid **MUST** be preserved
 to preserve the object's association with the correct template used for creation. UUID version 4 is **RECOMMENDED** when assigning it to a new object.
+
+template_uuid is represented as a JSON string. template_uuid **MUST** be present.
 
 #### template\_version
 
 template_version represents a numeric incrementing version of the template used to create the object. It is used to associate the object to the
 correct version of the template and together with the template_uuid forms an association to the correct template type and version.
 
-version is represented as a JSON string. version **MUST** be present.
+template_version is represented as a JSON string. template_version **MUST** be present.
 
 #### event\_id
 


### PR DESCRIPTION
Correct `Object`'s `template_uuid` and `template_version` attributes by adding a missing presence clause.

The clause was set to `MUST` as per the `Object` definition:

> A MISP document containing an Object **MUST** contain a name, a meta-category, a description, a template_uuid and a template_version as described in the "Object Attributes" section.

Furthermore, the attribute descriptions lacked the full attribute name as `template_uuid` and `template_version` were respectively referred to as `uuid` and `version`, causing a collision with the already defined `uuid` attribute of the `Object`.