### PR TITLE
Correct `Event` and `ShadowAttribute`'s `Orgc` and `Org`

### DIFF
--- a/misp-core-format/raw.md
+++ b/misp-core-format/raw.md
@@ -218,9 +218,9 @@ extends\_uuid represents which event is extended by this event. The extends\_uui
 
 extends\_uuid is represented as a JSON string. extends\_uuid **SHOULD** be present.
 
-## Objects
+### Event Objects
 
-### Org
+#### Org
 
 An Org object is composed of an uuid, name and id.
 
@@ -233,7 +233,7 @@ A human-readable identifier **MUST** be represented as an unsigned integer.
 
 uuid, name and id are represented as a JSON string. uuid, name and id **MUST** be present.
 
-#### Sample Org Object
+##### Sample Org Object
 
 ~~~~
 "Org": {
@@ -243,7 +243,7 @@ uuid, name and id are represented as a JSON string. uuid, name and id **MUST** b
        }
 ~~~~
 
-### Orgc
+#### Orgc
 
 An Orgc object is composed of an uuid, name and id.
 
@@ -650,7 +650,15 @@ last_seen represents a reference time when the attribute was last seen. last_see
 
 last_seen is represented as a JSON string. last_seen **MAY** be present.
 
-### Org
+#### value
+
+value represents the payload of an attribute. The format of the value is dependent on the type of the attribute.
+
+value is represented by a JSON string. value **MUST** be present.
+
+### ShadowAttribute Objects
+
+#### Org
 
 An Org object is composed of an uuid, name and id.
 
@@ -663,7 +671,7 @@ A human-readable identifier **MUST** be represented as an unsigned integer.
 
 uuid, name and id are represented as a JSON string. uuid, name and id **MUST** be present.
 
-#### Sample Org Object
+##### Sample Org Object
 
 ~~~~
 "Org": {
@@ -672,12 +680,6 @@ uuid, name and id are represented as a JSON string. uuid, name and id **MUST** b
         "uuid": "55f6ea5e-2c60-40e5-964f-47a8950d210f"
        }
 ~~~~
-
-#### value
-
-value represents the payload of an attribute. The format of the value is dependent on the type of the attribute.
-
-value is represented by a JSON string. value **MUST** be present.
 
 ## Object
 


### PR DESCRIPTION
**I'm unsure about this PR, review with care!**

Both `Event` and `ShadowAttribute`'s  objects were missing a depth-level. This resulted in `Event`'s `Org` and `Orgc` not being part of the `Event`.

![image](https://user-images.githubusercontent.com/46688461/152660023-161e598d-33f4-4a64-8022-d94553e3f93f.png)

For the `ShadowAttribute`, the `value` attribute was mentioned after the `Org` object which had an incorrect indentation. This results in the `ShadowAttribute`'s `value` being part of the `Org` and the `Org` being seen as a header.

![image](https://user-images.githubusercontent.com/46688461/152660094-0f9fb9cc-81b4-40a2-a111-d00c97d77c44.png)

![image](https://user-images.githubusercontent.com/46688461/152660120-31893023-3cd9-4269-8736-8ab78d191d18.png)
